### PR TITLE
Add deepLinking to swaggerUI generator

### DIFF
--- a/src/ui/src.js
+++ b/src/ui/src.js
@@ -28,5 +28,6 @@ SwaggerUI({
 	spec,
 	dom_id: '#swagger',
 	filter: true,
+	deepLinking: true,
 	plugins: [AdvancedFilterPlugin]
 })


### PR DESCRIPTION
Allow deepLinking to enable deep links to specific  in  Swagger UI

Example:
http://www.example.com/swagger/index.html#/Section/endpoint_name -> open specific endpoint in documentation

Usage:
- links between endpoint
- sharing with colaborators or in confluence, jira, etc.