### PR TITLE
INO-87: .alternatives() & .try() example formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can find simple examples of all mentioned in the demo folder of this reposit
 
 ## Usage example
 
-```
+```Typescript
 // imports
 import getSwagger from '@goodrequest/express-joi-to-swagger'
 import path from 'path'
@@ -117,7 +117,7 @@ workflow()
 
 
 Middlewares and router implementation.
-```bash
+```Typescript
 router.get(
 		'/users/:userID',
 		
@@ -137,7 +137,7 @@ export const permissionMiddleware = (allowPermissions: string[]) => function per
 
 ```
 Adding description for endpoints.
-```bash
+```Typescript
 const userEndpointDesc = 'This is how to add swagger description for this endpoint'
 
 export const requestSchema = Joi.object({
@@ -152,6 +152,38 @@ export const requestSchema = Joi.object({
 	})
 }).description(userEndpointDesc)
 
+```
+Top level request .alternatives() or .alternatives().try()..
+```Typescript
+export const requestSchema = Joi.object({
+    params: Joi.object(),
+    query: Joi.object(),
+    body: Joi.alternatives().try(
+        Joi.object().keys({
+            a: Joi.string(),
+            b: Joi.number()
+        }),
+        Joi.object().keys({
+            c: Joi.boolean(),
+            d: Joi.date()
+        })
+    )
+})
+
+```
+..displays request example as:
+```JSON
+{
+  "warning": ".alternatives() object - select 1 option only",
+  "option_0": {
+    "a": "string",
+    "b": 0
+  },
+  "option_1": {
+    "c": true,
+    "d": "2021-01-01T00:00:00.001Z"
+  }
+}
 ```
 
 ## Result

--- a/demo/endpoints/animals/index.ts
+++ b/demo/endpoints/animals/index.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import validationMiddleware from '../../middlewares/validationMiddleware'
 import * as getAnimals from './get.animals'
 import * as postAnimal from './post.animal'
+import * as postAnimalByFamily from './post.animalByFamily'
 
 const router = express.Router()
 
@@ -13,6 +14,10 @@ export default () => {
 	router.post('/',
 		validationMiddleware(postAnimal.requestSchema),
 		postAnimal.businessLogic)
+
+	router.post('/family',
+		validationMiddleware(postAnimalByFamily.requestSchema),
+		postAnimalByFamily.businessLogic)
 
 	return router
 }

--- a/demo/endpoints/animals/post.animalByFamily.ts
+++ b/demo/endpoints/animals/post.animalByFamily.ts
@@ -1,0 +1,33 @@
+import { NextFunction, Request, Response } from 'express'
+import Joi from 'joi'
+
+export const requestSchema = Joi.object({
+	params: Joi.object(),
+	query: Joi.object(),
+	body: Joi.alternatives().try(
+		Joi.object().keys({
+			name: Joi.string().min(1).required(),
+			animalFamily: Joi.string().valid('CANINE').invalid('FELINE').required(),
+			barkType: Joi.string().valid('WOOF', 'BARK', 'AWOO').required()
+		}),
+		Joi.object().keys({
+			name: Joi.string().min(1).required(),
+			animalFamily: Joi.string().valid('FELINE').invalid('CANINE').required(),
+			meowType: Joi.string().valid('PURR', 'MEOW', 'HISS').required()
+		}),
+	)
+})
+
+export const responseSchema = Joi.object({
+	message: Joi.string().min(1).required()
+})
+
+export const businessLogic = (req: Request, res: Response, next: NextFunction) => {
+	try {
+		return res.json({
+			message: 'OK'
+		})
+	} catch (e) {
+		return next(e)
+	}
+}

--- a/src/baseSwagger.ts
+++ b/src/baseSwagger.ts
@@ -237,6 +237,20 @@ export const createResponse = (
 	}
 })
 
+const prepAlternativesArray = (alts: any[]) => alts.reduce(
+	(acc: any, curr: any, index: number) => {
+		acc[`option_${index}`] = curr
+		return acc
+	}, {
+		warning: {
+			type: 'string',
+			enum: [
+				'.alternatives() object - select 1 option only'
+			]
+		}
+	}
+)
+
 const getPermissionDescription = (permissions: string[]): string => {
 	const permissionsResult = 'PERMISSION:'
 	if (!isEmpty(permissions)) {
@@ -303,7 +317,9 @@ export function getPathSwagger(swagger: SwaggerInput) {
 			if (method !== 'get' && method !== 'delete') {
 				requestBody = {
 					type: 'object',
-					properties: requestSwagger.properties.body.properties,
+					properties: requestSwagger.properties.body.anyOf
+						? prepAlternativesArray(requestSwagger.properties.body.anyOf)
+						: requestSwagger.properties.body.properties,
 					required: requestSwagger.properties.body.required
 				}
 			}

--- a/src/ui/data.json
+++ b/src/ui/data.json
@@ -125,6 +125,121 @@
 				}
 			}
 		},
+		"/api/v1/animals/family": {
+			"post": {
+				"tags": [
+					"Animals"
+				],
+				"summary": "PERMISSION: NO",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"message": {
+											"type": "string",
+											"minLength": 1
+										}
+									},
+									"required": [
+										"message"
+									],
+									"additionalProperties": false
+								}
+							}
+						}
+					}
+				},
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"warning": {
+										"type": "string",
+										"enum": [
+											".alternatives() object - select 1 option only"
+										]
+									},
+									"option_0": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"type": "string",
+												"minLength": 1
+											},
+											"animalFamily": {
+												"type": "string",
+												"enum": [
+													"CANINE"
+												],
+												"not": {
+													"enum": [
+														"FELINE"
+													]
+												}
+											},
+											"barkType": {
+												"type": "string",
+												"enum": [
+													"WOOF",
+													"BARK",
+													"AWOO"
+												]
+											}
+										},
+										"required": [
+											"name",
+											"animalFamily",
+											"barkType"
+										],
+										"additionalProperties": false
+									},
+									"option_1": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"type": "string",
+												"minLength": 1
+											},
+											"animalFamily": {
+												"type": "string",
+												"enum": [
+													"FELINE"
+												],
+												"not": {
+													"enum": [
+														"CANINE"
+													]
+												}
+											},
+											"meowType": {
+												"type": "string",
+												"enum": [
+													"PURR",
+													"MEOW",
+													"HISS"
+												]
+											}
+										},
+										"required": [
+											"name",
+											"animalFamily",
+											"meowType"
+										],
+										"additionalProperties": false
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/api/v1/users/{userID}": {
 			"get": {
 				"tags": [


### PR DESCRIPTION
This:
```Typescript
export const requestSchema = Joi.object({
    params: Joi.object(),
    query: Joi.object(),
    body: Joi.alternatives().try(
        Joi.object().keys({
            a: Joi.string(),
            b: Joi.number()
        }),
        Joi.object().keys({
            c: Joi.boolean(),
            d: Joi.date()
        })
    )
})
```

Into this:
```
{
  "warning": ".alternatives() object - select 1 option only",
  "option_0": {
    "a": "string",
    "b": 0
  },
  "option_1": {
    "c": true,
    "d": "2021-08-16T07:56:35.908Z"
  }
}
```

Instead of this:
```
{}
```

---
NOTE: .alternatives() examples work acceptably in responses.