### PR TITLE
Ino 198

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can find simple examples of all mentioned in the demo folder of this reposit
 ## Config parameters
 
 | Name										| Type   		| Required 			  |Description																			  						|
-| ------------------------------------------|---------------|:----------------------:|---------------------------------------------------------------------------------------------------- 			|
+| ------------------------------------------|-------------|:----------------------:|---------------------------------------------------------------------------------------------------- 			|
 | **outputPath**							| string  		|  ✅  | Path to directory where output JSON file should be created. 														                      						|
 | **generateUI**							| boolean 		|  ✅  | Whether [Swagger UI](https://swagger.io/tools/swagger-ui/) should be generated.					                                                  						|
 | **permissions**							| object  		|  ❌  | Configuration parameters for parsing permissions.
@@ -55,6 +55,7 @@ You can find simple examples of all mentioned in the demo folder of this reposit
 | **responseSchemaName**					| string  		|  ❌  | Name of the Joi schema object defining response structure.     |
 | **requestSchemaParams**					| any[]			|  ❌  | Param for ability to pass mock params for requestSchema			|
 | **responseSchemaParams**					| any[]			|  ❌  | Param for ability to pass mock params for responseSchema			|
+| **errorResponseSchemaName**				| string	    |  ❌  | Name of the Joi schema object defining error responses structure.	 |
 | **businessLogicName**						| string  		|  ✅  | Name of the function responsible for handling business logic of the request.     |
 | **swaggerInitInfo**						| ISwaggerInit 	|  ❌  | Swagger initial information.      |
 | **swaggerInitInfo**.servers				| IServer[] 	|  ❌  | List of API servers     |
@@ -97,6 +98,7 @@ const config: IConfig = {
 	requestSchemaName: 'requestSchema',
 	requestSchemaParams: [mockFn],
 	responseSchemaName: 'responseSchema',
+	errorResponseSchemaName: 'errorResponseSchemas',
 	businessLogicName: 'businessLogic',
 	swaggerInitInfo: {
 		info: {

--- a/demo/endpoints/users/get.user.ts
+++ b/demo/endpoints/users/get.user.ts
@@ -26,6 +26,23 @@ export const responseSchema = Joi.object({
 	}),
 })
 
+export const errorResponseSchemas = [
+	Joi.object({
+		messages: Joi.array().items(Joi.object({
+			type: Joi.string().required(),
+			message: Joi.string().required().example('Not found')
+			})
+		)
+	}).description('404'),
+	Joi.object({
+		messages: Joi.array().items(Joi.object({
+				type: Joi.string().required(),
+				message: Joi.string().required().example('Conflict')
+			})
+		)
+	}).description('409')
+]
+
 export const businessLogic = (req: Request, res: Response, next: NextFunction) => {
 	try {
 		const { userID } = req.params

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -17,6 +17,7 @@ const config: IConfig = {
 	requestSchemaName: 'requestSchema',
 	requestSchemaParams: [mockTranslateFn],
 	responseSchemaName: 'responseSchema',
+	errorResponseSchemaName: 'errorResponseSchemas',
 	businessLogicName: 'businessLogic',
 	swaggerInitInfo: {
 		info: {

--- a/demo/samples/editableSwaggerDemo.ts
+++ b/demo/samples/editableSwaggerDemo.ts
@@ -12,6 +12,7 @@ const config: IConfig = {
 	}],
 	requestSchemaName: 'requestSchema',
 	responseSchemaName: 'responseSchema',
+	errorResponseSchemaName: 'errorResponseSchemas',
 	businessLogicName: 'businessLogic',
 	swaggerInitInfo: {
 		info: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@goodrequest/express-joi-to-swagger",
-  "version": "0.11.0",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@goodrequest/express-joi-to-swagger",
-      "version": "0.11.0",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "buffer": "6.0.3",

--- a/src/baseSwagger.ts
+++ b/src/baseSwagger.ts
@@ -224,13 +224,25 @@ interface SwaggerInput {
 
 export type ResponseCode = 200 | 300 | 400 | 401 | 403 | 404 | 409
 
+const formatResponseDescription = (code: ResponseCode, description?: string) => {
+	if (description) {
+		return description
+	}
+
+	if (code >= 400) {
+		return 'Error response'
+	}
+
+	return 'Success response'
+}
+
 export const createResponse = (
 	responseSchema: any,
 	code: ResponseCode, // TODO: add more response codes
 	description?: string
 ) => ({
 	[code]: {
-		description: description || 'Success response',
+		description: formatResponseDescription(code, description),
 		content: {
 			'application/json': {
 				schema: responseSchema

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -31,6 +31,7 @@ export interface IConfig {
 	requestSchemaParams?: any[]
 	responseSchemaName?: string
 	responseSchemaParams?: any[]
+	errorResponseSchemaName?: string
 	businessLogicName: string
 	swaggerInitInfo?: ISwaggerInit
 	tags?: {
@@ -342,6 +343,20 @@ export const parseExpressRoute = async (route: IRoute, basePath: string, config:
 					responses.push({
 						outputJoiSchema,
 						code: 200
+					})
+				}
+
+				// Handle error responses from array
+				if (has(workflow, config.errorResponseSchemaName)) {
+					const outputJoiSchemas = get(workflow, config.errorResponseSchemaName)
+
+					outputJoiSchemas.forEach((outputJoiSchema: Schema) => {
+						responses.push({
+							outputJoiSchema,
+							// Accessing schema property
+							// eslint-disable-next-line no-underscore-dangle
+							code: outputJoiSchema._flags.description
+						})
 					})
 				}
 			}


### PR DESCRIPTION
In limited options, **description** seemed like ok place where to put status code, but I am open for another suggestion.
 
UI can be modified with red background for error codes, but I have not added it yet, as this might be more opinionated. It might look like this:

![Screenshot from 2023-08-18 10-13-26](https://github.com/GoodRequest/express-joi-to-swagger/assets/124373894/97c4f52a-f3b0-4f3e-aeae-8d7fcb2f130d)
