### PR TITLE
chore: add Dependabot and CI workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     cooldown:
-      default-days: 3
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -16,4 +16,4 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     cooldown:
-      default-days: 3
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - run: npm install --legacy-peer-deps
+
+      - run: npm run lint
+
+      - run: npm run type-check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
 
-      - run: npm install --legacy-peer-deps
+      - run: npm ci
 
       - run: npm run lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@typescript-eslint/eslint-plugin": "7.16.0",
 				"ajv": "8.18.0",
 				"copyfiles": "2.4.1",
-				"eslint": "8.55.0",
+				"eslint": "8.57.1",
 				"eslint-plugin-import": "2.29.1",
 				"eslint-plugin-prettier": "5.1.3",
 				"husky": "9.1.7",
@@ -146,10 +146,11 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.55.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
-			"integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -222,13 +223,15 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.13",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+			"deprecated": "Use @eslint/config-array instead",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.3",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
 			"engines": {
@@ -249,10 +252,12 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
-			"dev": true
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.3",
@@ -2419,16 +2424,18 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.55.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
-			"integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
 				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.55.0",
-				"@humanwhocodes/config-array": "^0.11.13",
+				"@eslint/js": "8.57.1",
+				"@humanwhocodes/config-array": "^0.13.0",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"@ungap/structured-clone": "^1.2.0",
@@ -5855,7 +5862,6 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"@typescript-eslint/eslint-plugin": "7.16.0",
 		"ajv": "8.18.0",
 		"copyfiles": "2.4.1",
-		"eslint": "8.55.0",
+		"eslint": "8.57.1",
 		"eslint-plugin-import": "2.29.1",
 		"eslint-plugin-prettier": "5.1.3",
 		"husky": "9.1.7",


### PR DESCRIPTION
Hi guys, I was passing by (summoned by some notification about release). I have created github action to automatically update npm packages and github action workflows. If you like it you can grab it and tweak it as you like. Check summary below for options.

## Summary

- Added `.github/dependabot.yml` monitoring `github-actions` and `npm` ecosystems — weekly on Monday, 5 PR limit, manual review
- 3-day cooldown on both ecosystems to mitigate supply chain attacks (delays PRs until a release has been public for 3 days)
- Added `.github/workflows/ci.yaml` running `lint` + `type-check` on every PR, push to `main`, and manually via **Actions → CI → Run workflow**

## Dependabot options

| Option | Value |
|---|---|
| `schedule.interval` | `weekly` |
| `schedule.day` | `monday` |
| `open-pull-requests-limit` | `5` |
| `cooldown.default-days` | `3` |

## Manual triggers

- **CI** — triggerable from Actions → CI → Run workflow (`workflow_dispatch`)
- **Dependabot** — triggerable from Security → Dependabot → "Check for updates"

✌️ 